### PR TITLE
Update mavlink-parser-base.ts

### DIFF
--- a/src/mavlink-parser-base.ts
+++ b/src/mavlink-parser-base.ts
@@ -76,7 +76,7 @@ export abstract class MAVLinkParserBase {
                         }
                         this.buffer = this.buffer.slice(this.expected_packet_length);
                     } catch (e) {
-                        this.buffer = this.buffer.slice(1);
+                        this.buffer = Buffer.from("");
                         throw e;
                     } finally {
                         // something was complete. Regardless of a complete message, drop the magic byte and restart.


### PR DESCRIPTION
- Fixed errors that continued to accumulate data in buffer and were not parsed when connected via TCP.
- TCP로 연결하면 buffer에 계속 데이터가 쌓이고 파싱이 되지 않던 오류 수정